### PR TITLE
replace ref and export let to const

### DIFF
--- a/src/Desktop.js
+++ b/src/Desktop.js
@@ -30,4 +30,4 @@ export default class Desktop {
   })();
 }
 
-export let OS = Desktop.OS;
+export const OS = Desktop.OS;

--- a/src/Form.js
+++ b/src/Form.js
@@ -103,14 +103,14 @@ class Form extends Component {
       }
 
       if (element.type === Row) {
-        let ref = `row-${index}`;
+        const ref = `row-${index}`;
         return (
           <RowWrapper ref={ref} style={style}>
             {cloneElement(element, {form: this})}
           </RowWrapper>
         );
       } else if (element.type === Label) {
-        let ref = `label-${index}`;
+        const ref = `label-${index}`;
         return (
           <RowWrapper ref={ref} style={this.styles.label}>
             {cloneElement(element, {form: this})}


### PR DESCRIPTION
Maybe it worth to enable eslint's [no-const-assign](http://eslint.org/docs/rules/no-const-assign) and [prefer-const](http://eslint.org/docs/rules/prefer-const) rules or even enable `eslint-confib-airbnb` extend?