### PR TITLE
remove assign to merged in mergeStyles

### DIFF
--- a/src/Styling.js
+++ b/src/Styling.js
@@ -65,7 +65,7 @@ function addRawStyle(stylesheet) {
 export function mergeStyles(...styles) {
   let merged = {};
   for (const style of styles) {
-    merged = Object.assign(merged, style);
+    Object.assign(merged, style);
   }
   return merged;
 }


### PR DESCRIPTION
Object.assign(target, style) will copy style's properties to target and return target.

```
Object.assign(merged, style);
```

is equivalent to

```
merged = Object.assign(merged, style);
```