### PR TITLE
[gh-pages] Fix trailing slash -> module not found

### DIFF
--- a/src/Docs/Docs.js
+++ b/src/Docs/Docs.js
@@ -34,7 +34,7 @@ export default class extends Component {
     let content;
     if (this.props.params.splat) {
       if (this.props.location.pathname.match(/\/$/)) {
-        content = require(`../../raw-docs/${this.props.params.splat}/index.html`);
+        content = require(`../../raw-docs/${this.props.params.splat}.html`);
       } else {
         content = require(`../../raw-docs/${this.props.params.splat}.html`);
       }


### PR DESCRIPTION
fix trailing slash cause
Uncaught Error: Cannot find module './components/windows/Button/index.html'.

relative to #27