### PR TITLE
add tests for module exporting

### DIFF
--- a/src/ProgressRing/Animation.js
+++ b/src/ProgressRing/Animation.js
@@ -1,7 +1,7 @@
 import BezierEasing from '../Animation/BezierEasing';
 
 let requestAnimationFrame;
-if (window) {
+if (typeof window !== 'undefined') {
   requestAnimationFrame = window.requestAnimationFrame ||
     window.mozRequestAnimationFrame ||
     window.webkitRequestAnimationFrame ||

--- a/test/OSX.js
+++ b/test/OSX.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import {
+  Box,
+  Form,
+  IndeterminateCircularProgressIndicator,
+  Label,
+  PushButton,
+  SegmentedControl,
+  TextField,
+  TitleBar,
+  Toolbar,
+  Window
+} from '../src/OSX';
+
+describe('OSX', () => {
+  it('should be exported', () => {
+    expect(Box).to.exist;
+    expect(Form).to.exist;
+    expect(IndeterminateCircularProgressIndicator).to.exist;
+    expect(Label).to.exist;
+    expect(PushButton).to.exist;
+    expect(SegmentedControl).to.exist;
+    expect(TextField).to.exist;
+    expect(TitleBar).to.exist;
+    expect(Toolbar).to.exist;
+    expect(Window).to.exist;
+  });
+});

--- a/test/Windows.js
+++ b/test/Windows.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+import {
+  Button,
+  Form,
+  ProgressRing,
+  TextBlock,
+  TextBox,
+  TitleBar,
+  Window,
+  Checkbox,
+  SplitView,
+  Grid
+} from '../src/Windows';
+
+describe('Windows', () => {
+  it('should be exported', () => {
+    expect(Button).to.exist;
+    expect(Form).to.exist;
+    expect(ProgressRing).to.exist;
+    expect(TextBlock).to.exist;
+    expect(TextBox).to.exist;
+    expect(TitleBar).to.exist;
+    expect(Window).to.exist;
+    expect(Checkbox).to.exist;
+    expect(SplitView).to.exist;
+    expect(Grid).to.exist;
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import {
+  Box,
+  Button,
+  Desktop,
+  Form,
+  IndeterminateProgressWheel,
+  Label,
+  SegmentedControl,
+  TextBlock,
+  TextInput,
+  Toolbar,
+  TitleBar,
+  Window,
+  Checkbox,
+  SplitView,
+  Windows,
+  OSX
+} from '../src/index';
+
+describe('index', () => {
+  it('should be exported', () => {
+    expect(Box).to.exist;
+    expect(Button).to.exist;
+    expect(Desktop).to.exist;
+    expect(Form).to.exist;
+    expect(IndeterminateProgressWheel).to.exist;
+    expect(Label).to.exist;
+    expect(SegmentedControl).to.exist;
+    expect(TextBlock).to.exist;
+    expect(TextInput).to.exist;
+    expect(Toolbar).to.exist;
+    expect(TitleBar).to.exist;
+    expect(Window).to.exist;
+    expect(Checkbox).to.exist;
+    expect(SplitView).to.exist;
+    expect(Windows).to.exist;
+    expect(OSX).to.exist;
+  });
+});


### PR DESCRIPTION
```js
if (window) {
```

will throw `ReferenceError: window is not defined`, so I change it to

```js
if (typeof window !== 'undefined') {
```