### PR TITLE
feat: Add public `focus` and `blur` methods to TextInput

### DIFF
--- a/docs/mac-os/box.md
+++ b/docs/mac-os/box.md
@@ -22,6 +22,14 @@ paddingTop          | string, number | Sets the padding top inside a component.
 verticalAlignment   | string         | Sets the vertical alignment of the component's content.<br/>__Property value__ _"top"_, _"center"_, _"bottom"_
 width               | number         | Sets the width of a component.
 
+### Methods
+
+Method              | Type           | Description
+:------------------ | :-------------:| :----------
+focus               | function       | Focus text input programmatically
+blur                | function       | Remove focus from text input programmatically
+
+
 ### Examples
 
 ```jsx

--- a/src/textInput/macOs/textInput.js
+++ b/src/textInput/macOs/textInput.js
@@ -130,6 +130,24 @@ class TextFieldOSX extends Component {
     setTimeout(() => this.setState({ isFocused: true }));
   };
 
+  /**
+   * Remove the focus programmatically
+   * @public
+   * */
+  blur() {
+    const inputEl = ReactDOM.findDOMNode(this.refs.element)
+    inputEl.blur();
+  }
+
+  /**
+   * Focus the input programmatically
+   * @public
+   */
+  focus() {
+    const inputEl = ReactDOM.findDOMNode(this.refs.element)
+    inputEl.focus();
+  }
+
   render() {
     let { style, label, size, rounded, focusRing, placeholder, centerPlaceholder, icon, password, ...props } = this.props;
     delete props.onEnter;

--- a/src/textInput/windows/textInput.js
+++ b/src/textInput/windows/textInput.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import ReactDOM from 'react-dom';
 import Text from '../../text/windows/text';
 import Hidden, { hiddenPropTypes } from '../../style/hidden';
 import Dimension, { dimensionPropTypes } from '../../style/dimension';
@@ -41,6 +42,24 @@ class TextInput extends Component {
     return this.context.theme === 'dark' ? styles[':placeholderDarkTheme'] : styles[':placeholder'];
   }
 
+  /**
+   * Remove the focus programmatically
+   * @public
+   * */
+  blur() {
+    const inputEl = ReactDOM.findDOMNode(this.refs.element)
+    inputEl.blur();
+  }
+
+  /**
+   * Focus the input programmatically
+   * @public
+   */
+  focus() {
+    const inputEl = ReactDOM.findDOMNode(this.refs.element)
+    inputEl.focus();
+  }
+
   render() {
     let { label, labelColor, labelStyle, style, password, ...props } = this.props;
     let componentStyle = { ...styles.textBox, ...style };
@@ -61,6 +80,7 @@ class TextInput extends Component {
       <PlaceholderStyle placeholderStyle={this.placeholderStyle}>
         {Background(
           <input
+            ref="element"
             type={`${password ? 'password' : 'text'}`}
             style={componentStyle}
             {...props}


### PR DESCRIPTION
This PR adds 2 public methods `focus` and `blur` that mimic DOM API to TextInput component.