### PR TITLE
Export Controls component as TitleBarControls for custom title bars

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ export const SegmentedControlItem = macOs.SegmentedControlItem;
 export const Text = select(macOs.Text, windows.Text);
 export const TextInput = select(macOs.TextInput, windows.TextInput);
 export const TitleBar = select(macOs.TitleBar, windows.TitleBar);
+export const TitleBarControls = select(macOs.TitleBarControls, windows.TitleBarControls);
 export const Toolbar = macOs.Toolbar;
 export const ToolbarNav = macOs.ToolbarNav;
 export const ToolbarNavItem = macOs.ToolbarNavItem;

--- a/macOs.js
+++ b/macOs.js
@@ -20,6 +20,7 @@ export { default as SegmentedControlItem } from './src/segmentedControl/macOs/it
 export { default as Text } from './src/text/macOs/text';
 export { default as TextInput } from './src/textInput/macOs/textInput';
 export { default as TitleBar } from './src/titleBar/macOs/titleBar';
+export { default as TitleBarControls } from './src/titleBar/macOs/controls/controls'
 export { default as Toolbar } from './src/toolbar/macOs/toolbar';
 export { default as ToolbarNav } from './src/toolbar/macOs/nav/nav';
 export { default as ToolbarNavItem } from './src/toolbar/macOs/nav/item/item';

--- a/windows.js
+++ b/windows.js
@@ -12,5 +12,6 @@ export { default as Radio } from './src/radio/windows/radio';
 export { default as Text } from './src/text/windows/text';
 export { default as TextInput } from './src/textInput/windows/textInput';
 export { default as TitleBar } from './src/titleBar/windows/titleBar';
+export { default as TitleBarControls } from './src/titleBar/windows/controls/controls'
 export { default as View } from './src/view/windows/view';
 export { default as Window } from './src/window/windows/window';


### PR DESCRIPTION
In order to reuse the Controls component of TitleBar for custom title bars, the component needs to be exported by the module. I suggest exporting it as "TitleBarControls". 

Simplified usage example:

```typescript
import {TitleBarControls} from "react-desktop"
import * as React from "react"

export default class MyCustomTitleBar extends React.Component {
  render() {
    return <div className="MyCustomTitleBar">WINDOW TITLE <TitleBarControls/></div>
  }
}
```