### PR TITLE
Get rid of titles on TitleBar buttons

### DIFF
--- a/src/TitleBar/windows/Controls/Close.js
+++ b/src/TitleBar/windows/Controls/Close.js
@@ -64,7 +64,6 @@ class Close extends Component {
 
     return (
       <a
-        title="Close"
         style={componentStyle}
         {...props}
       >

--- a/src/TitleBar/windows/Controls/Maximize.js
+++ b/src/TitleBar/windows/Controls/Maximize.js
@@ -97,7 +97,6 @@ class Maximize extends Component {
 
     return (
       <a
-        title={title}
         style={componentStyle}
         onClick={onClick}
         {...props}

--- a/src/TitleBar/windows/Controls/Minimize.js
+++ b/src/TitleBar/windows/Controls/Minimize.js
@@ -70,7 +70,6 @@ class Minimize extends Component {
 
     return (
       <a
-        title="Minimize"
         style={componentStyle}
         {...props}
       >


### PR DESCRIPTION
Sometimes tooltips for the titlebar buttons can get stuck on screen. See a similar issue here: https://github.com/desktop/desktop/issues/2874