### PR TITLE
Add ability to show titlebar controls in disabled style

### DIFF
--- a/docs/mac-os/title-bar.md
+++ b/docs/mac-os/title-bar.md
@@ -13,6 +13,9 @@ onMinimizeClick     | function     | Callback function of the minimize button
 onResizeClick       | function     | Callback function of the resize button
 title               | string       | Sets the title of the title bar.
 transparent         | bool         | Make the title bar background transparent.
+disableClose        | bool         | Disable the close button.
+disableMinimize     | bool         | Disable the minimize button.
+disableReize        | bool         | Disable the resize button.
 
 ### Examples
 

--- a/src/TitleBar/macOs/Controls/Close.js
+++ b/src/TitleBar/macOs/Controls/Close.js
@@ -9,22 +9,26 @@ import Radium from 'radium';
 class Close extends Component {
   static propTypes = {
     style: PropTypes.object,
-    showIcon: PropTypes.bool
+    showIcon: PropTypes.bool,
+    disabled: PropTypes.bool
   };
 
   render() {
-    const { style, isWindowFocused, showIcon, ...props } = this.props;
+    const { style, isWindowFocused, showIcon, disabled, ...props } = this.props;
 
     delete props.isFullscreen;
 
     const iconStyle = {
       ...styles.close.icon,
-      opacity: showIcon ? 1 : 0
+      opacity: showIcon && !disabled ? 1 : 0
     };
 
     let componentStyle = { ...styles.close.button, ...style };
     if (!isWindowFocused && !showIcon) {
       componentStyle = { ...componentStyle, ...styles.close.unfocused };
+    }
+    if (disabled) {
+      componentStyle = { ...componentStyle, ...styles.close.disabled };
     }
 
     return (

--- a/src/TitleBar/macOs/Controls/Minimize.js
+++ b/src/TitleBar/macOs/Controls/Minimize.js
@@ -9,22 +9,26 @@ import Radium from 'radium';
 class Minimize extends Component {
   static propTypes = {
     style: PropTypes.object,
-    showIcon: PropTypes.bool
+    showIcon: PropTypes.bool,
+    disabled: PropTypes.bool
   };
 
   render() {
-    const { style, isWindowFocused, showIcon, ...props } = this.props;
+    const { style, isWindowFocused, showIcon, disabled, ...props } = this.props;
 
     delete props.isFullscreen;
 
     const iconStyle = {
       ...styles.minimize.icon,
-      opacity: showIcon ? 1 : 0
+      opacity: showIcon && !disabled ? 1 : 0
     };
 
     let componentStyle = { ...styles.minimize.button, ...style };
     if (!isWindowFocused && !showIcon) {
       componentStyle = { ...componentStyle, ...styles.minimize.unfocused };
+    }
+    if (disabled) {
+      componentStyle = { ...componentStyle, ...styles.minimize.disabled };
     }
 
     return (

--- a/src/TitleBar/macOs/Controls/Resize.js
+++ b/src/TitleBar/macOs/Controls/Resize.js
@@ -9,7 +9,8 @@ import Radium from 'radium';
 class Resize extends Component {
   static propTypes = {
     isFullscreen: PropTypes.bool,
-    showIcon: PropTypes.bool
+    showIcon: PropTypes.bool,
+    disabled: PropTypes.bool
   };
 
   componentDidMount() {
@@ -26,18 +27,29 @@ class Resize extends Component {
   };
 
   render() {
-    let { style, onClick, onMaximizeClick, isWindowFocused, showIcon, ...props } = this.props;
+    let {
+      style,
+      onClick,
+      onMaximizeClick,
+      isWindowFocused,
+      showIcon,
+      disabled,
+      ...props
+    } = this.props;
 
     delete props.isFullscreen;
 
     let iconStyle = {
       ...styles.resize.icon,
-      opacity: showIcon ? 1 : 0
+      opacity: showIcon && !disabled ? 1 : 0
     };
 
     let componentStyle = { ...styles.resize.button, ...style };
     if (!isWindowFocused && !showIcon) {
       componentStyle = { ...componentStyle, ...styles.resize.unfocused };
+    }
+    if (disabled) {
+      componentStyle = { ...componentStyle, ...styles.resize.disabled };
     }
 
     let icon;

--- a/src/TitleBar/macOs/Controls/index.js
+++ b/src/TitleBar/macOs/Controls/index.js
@@ -25,7 +25,10 @@ class Controls extends Component {
     onCloseClick: PropTypes.func,
     onMinimizeClick: PropTypes.func,
     onMaximizeClick: PropTypes.func,
-    onResizeClick: PropTypes.func
+    onResizeClick: PropTypes.func,
+    disableClose: PropTypes.bool,
+    disableMinimize: PropTypes.bool,
+    disableResize: PropTypes.bool
   };
 
   constructor() {
@@ -42,16 +45,22 @@ class Controls extends Component {
         onMouseEnter={() => this.setState({ isOver: true })}
         onMouseLeave={() => this.setState({ isOver: false })}
       >
-        <Close onClick={this.props.onCloseClick} showIcon={this.state.isOver} />
+        <Close
+          onClick={this.props.onCloseClick}
+          showIcon={this.state.isOver}
+          disabled={this.props.disableClose}
+        />
         <Minimize
           onClick={this.props.onMinimizeClick}
           showIcon={this.state.isOver}
+          disabled={this.props.disableMinimize}
         />
         <Resize
           isFullscreen={this.props.isFullscreen}
           onClick={this.props.onResizeClick}
           onMaximizeClick={this.props.onMaximizeClick}
           showIcon={this.state.isOver}
+          disabled={this.props.disableResize}
         />
       </div>
     );

--- a/src/TitleBar/macOs/Controls/styles/10.11.js
+++ b/src/TitleBar/macOs/Controls/styles/10.11.js
@@ -29,6 +29,15 @@ export default {
       borderColor: '#d0d0d0',
     },
 
+    disabled: {
+      backgroundColor: '#dddddd',
+      borderColor: '#d0d0d0',
+      ':active': {
+        backgroundColor: '#dddddd',
+        borderColor: '#d0d0d0'
+      }
+    },
+
     icon: {
       width: '10px',
       height: '10px'
@@ -65,6 +74,15 @@ export default {
       borderColor: '#d0d0d0',
     },
 
+    disabled: {
+      backgroundColor: '#dddddd',
+      borderColor: '#d0d0d0',
+      ':active': {
+        backgroundColor: '#dddddd',
+        borderColor: '#d0d0d0'
+      }
+    },
+
     icon: {
       width: '10px',
       height: '10px'
@@ -99,6 +117,15 @@ export default {
     unfocused: {
       backgroundColor: '#dddddd',
       borderColor: '#d0d0d0'
+    },
+
+    disabled: {
+      backgroundColor: '#dddddd',
+      borderColor: '#d0d0d0',
+      ':active': {
+        backgroundColor: '#dddddd',
+        borderColor: '#d0d0d0'
+      }
     },
 
     icon: {

--- a/src/TitleBar/macOs/index.js
+++ b/src/TitleBar/macOs/index.js
@@ -18,7 +18,10 @@ class TitleBar extends Component {
     onCloseClick: PropTypes.func,
     onMinimizeClick: PropTypes.func,
     onMaximizeClick: PropTypes.func,
-    onResizeClick: PropTypes.func
+    onResizeClick: PropTypes.func,
+    disableClose: PropTypes.bool,
+    disableMinimize: PropTypes.bool,
+    disableResize: PropTypes.bool
   };
 
   static childContextTypes = {


### PR DESCRIPTION
Titlebar controls can be disabled on macOS (not sure what the status is on windows) so I added this functionality.

Usage is:

```jsx
<TitleBar
  title="untitled text 5"
  controls
  isFullscreen={this.state.isFullscreen}
  onCloseClick={() => console.log('Close window')}
  onMinimizeClick={() => console.log('Minimize window')}
  onMaximizeClick={() => console.log('Mazimize window')}
  onResizeClick={() => this.setState({ isFullscreen: !this.state.isFullscreen })}
  disableClose
  disableMinimize
  disableResize
/>
```

And it looks like this:

![image](https://user-images.githubusercontent.com/26971/42419424-a4ba1720-82ac-11e8-9fcf-6d561469312c.png)

Button styling stays disabled (i.e. doesn't change) on hover or focus. It should also be noted that this not effect click handlers (e.g.. `onCloseClick`). Users can do this in their application code instead.