### PR TITLE
Allow end-user to force `isWindowFocused` prop

### DIFF
--- a/src/TitleBar/macOs/Controls/index.js
+++ b/src/TitleBar/macOs/Controls/index.js
@@ -42,16 +42,22 @@ class Controls extends Component {
         onMouseEnter={() => this.setState({ isOver: true })}
         onMouseLeave={() => this.setState({ isOver: false })}
       >
-        <Close onClick={this.props.onCloseClick} showIcon={this.state.isOver} />
+        <Close
+          onClick={this.props.onCloseClick}
+          showIcon={this.state.isOver}
+          isWindowFocused={this.props.isWindowFocused}
+        />
         <Minimize
           onClick={this.props.onMinimizeClick}
           showIcon={this.state.isOver}
+          isWindowFocused={this.props.isWindowFocused}
         />
         <Resize
           isFullscreen={this.props.isFullscreen}
           onClick={this.props.onResizeClick}
           onMaximizeClick={this.props.onMaximizeClick}
           showIcon={this.state.isOver}
+          isWindowFocused={this.props.isWindowFocused}
         />
       </div>
     );


### PR DESCRIPTION
This change allows the `TitleBar` component to forced into the focused or unfocused state. It already works for the `Window` component so no change was needed. I need this functionality for my app. If the prop isn't manually specified then existing behaviour will remain the same (i.e. focus will change depending on window focus).

Usage:

```jsx
<Window
  chrome={true}
  height="600px"
  width="800px"
  padding="0"
  isWindowFocused={true}
>
  <TitleBar
    title="Lorem Ipsum"
    controls={true}
    isWindowFocused={true}
  />
</Window>
```