### PR TITLE
Upgrade webpack-cli to fix running the playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "react-dom": "^16.3.0",
     "react-hot-loader": "^4.0.1",
     "webpack": "^4.4.1",
-    "webpack-cli": "^2.0.13",
+    "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.1"
   }
 }


### PR DESCRIPTION
Running the playground fails with `TypeError: Cannot read property 'properties' of undefined` at `webpack-cli/bin/config-yargs.js:89`. 
Upgrading **webpack-cli** fixes the issue.