### PR TITLE
Fix compatibility with react-hot-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-desktop",
   "author": "Gabriel Bull",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "React UI Components for macOS High Sierra and Windows 10",
   "main": "./index.js",
   "keywords": [

--- a/src/ListView/macOs/index.js
+++ b/src/ListView/macOs/index.js
@@ -29,9 +29,13 @@ class ListView extends Component {
       items = null,
       footer = null;
     Children.map(children, child => {
-      if (child.type === Header) return (header = child);
-      else if (child.type === Footer) return (footer = child);
-      else if (child.type === Row) hasDirectRows = true;
+      const HeaderEl = <Header />;
+      const FooterEl = <Footer />;
+      const RowEl = <Row />;
+
+      if (child.type === HeaderEl.type) return (header = child);
+      else if (child.type === FooterEl.type) return (footer = child);
+      else if (child.type === RowEl.type) hasDirectRows = true;
 
       if (!items) items = [];
       items.push(child);

--- a/src/MasterDetailsView/windows/index.js
+++ b/src/MasterDetailsView/windows/index.js
@@ -93,7 +93,9 @@ class MasterDetailsView extends Component {
     this.maxWidth = null;
     Children.map(children, (item, key) => {
       Children.map(item.props.children, child => {
-        if (child.type === Master) {
+        const MasterEl = <Master />;
+        const DetailsEl = <Details />;
+        if (child.type === MasterEl.type) {
           if (
             child.props.width !== undefined &&
             child.props.width > this.maxWidth
@@ -104,7 +106,7 @@ class MasterDetailsView extends Component {
             ...this.masters,
             cloneElement(child, { key: key, index: key })
           ];
-        } else if (child.type === Details) {
+        } else if (child.type === DetailsEl.type) {
           this.details = [
             ...this.details,
             cloneElement(child, { key: key, index: key })

--- a/src/Window/macOs/index.js
+++ b/src/Window/macOs/index.js
@@ -34,7 +34,8 @@ class Window extends Component {
     let titleBar = '';
     let otherChildren = [];
     Children.map(this.props.children, element => {
-      if (element.type === TitleBar) {
+      const childEl = <TitleBar />;
+      if (element.type === childEl.type) {
         titleBar = element;
       } else {
         otherChildren = [...otherChildren, element];

--- a/src/Window/macOs/index.js
+++ b/src/Window/macOs/index.js
@@ -34,8 +34,8 @@ class Window extends Component {
     let titleBar = '';
     let otherChildren = [];
     Children.map(this.props.children, element => {
-      const childEl = <TitleBar />;
-      if (element.type === childEl.type) {
+      const TitleBarEl = <TitleBar />;
+      if (element.type === TitleBarEl.type) {
         titleBar = element;
       } else {
         otherChildren = [...otherChildren, element];

--- a/src/Window/windows/index.js
+++ b/src/Window/windows/index.js
@@ -48,7 +48,8 @@ class Window extends Component {
     let titleBar = '';
     let otherChildren = [];
     Children.map(this.props.children, element => {
-      if (element.type === TitleBar) {
+      const TitleBarEl = <TitleBar />;
+      if (element.type === TitleBarEl.type) {
         titleBar = element;
       } else {
         otherChildren = [...otherChildren, element];


### PR DESCRIPTION
Element reference types cannot be compared directly if you're using react-hot-loader. This is a workaround. See https://github.com/gaearon/react-hot-loader/issues/304 for more.