### PR TITLE
optimize the style of NavPane-Button to avoid damage

### DIFF
--- a/src/NavPane/windows/Pane/style/windows10.js
+++ b/src/NavPane/windows/Pane/style/windows10.js
@@ -21,7 +21,8 @@ export default {
     top: '7px',
     left: '4px',
     width: '20px',
-    height: '20px'
+    height: '20px',
+    boxSizing: 'content-box'
   },
 
   anchor: {


### PR DESCRIPTION
The NavPane of button style will be broken if there is a global style like [antd](https://ant.design/):
```css
* {
  box-sizing: border-box
}
```
So it's style should be optimize to avoid damage.

![image](https://user-images.githubusercontent.com/7923987/69214386-cde1f800-0ba1-11ea-916d-9888f29c9c03.png)
