### PR TITLE
Update Close.js

### DIFF
--- a/src/TitleBar/windows/Controls/Close.js
+++ b/src/TitleBar/windows/Controls/Close.js
@@ -17,6 +17,7 @@ const styles = {
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
+    display: 'flex',
 
     ':hover': {
       transition: 'background-color 0.1s',


### PR DESCRIPTION
```display: 'flex'``` Fixes title bar control buttons collapse bug