### PR TITLE
Debug: fix window is undefined bug on next.js framework

### DIFF
--- a/src/os.js
+++ b/src/os.js
@@ -1,28 +1,36 @@
-export const MACOS = 'macOs';
-export const WINDOWS = 'windows';
+"use strict";
 
-export default function os() {
-  // explicitly set these to avoid issues
-  const w = window || null;
-  const n = navigator || null;
-  const p = process || (w && w.process) || null;
+Object.defineProperty(exports, "__esModule", {
+  value: true,
+});
+exports.default = os;
+var MACOS = (exports.MACOS = "macOs");
+var WINDOWS = (exports.WINDOWS = "windows");
+
+function os() {
+  // Check if we are running in a browser
+  var isBrowser =
+    typeof window !== "undefined" && typeof navigator !== "undefined";
+
+  // get process from window if it exists there
+  var p = isBrowser ? window.process : process;
 
   // via node
   if (p && p.platform) {
-    if (p.platform === 'darwin') {
+    if (p.platform === "darwin") {
       return MACOS;
     }
-    if (p.platform.includes('win')) {
+    if (p.platform.includes("win")) {
       return WINDOWS;
     }
   }
 
   // via user agent
-  if (n && n.userAgent) {
-    if (n.userAgent.includes('Macintosh')) {
+  if (isBrowser && navigator.userAgent) {
+    if (navigator.userAgent.includes("Macintosh")) {
       return MACOS;
     }
-    if (n.userAgent.includes('Windows')) {
+    if (navigator.userAgent.includes("Windows")) {
       return WINDOWS;
     }
   }


### PR DESCRIPTION
Hi,

I was using this library in a Next.js application and ran into a bug in the os.js folder where 'window' was undefined since there is no 'window' object on the server side.

To resolve this issue I added some additional checking to see if the code was executing in a browser environment before trying to access the 'window' object. 

I've attached an image of the error below.

<img width="398" alt="image" src="https://github.com/gabrielbull/react-desktop/assets/29559541/aab9829a-a01d-4c29-aac0-7e98d87adde2">
